### PR TITLE
feat(prisma): add Document model with status enum and relations to User

### DIFF
--- a/prisma/migrations/20250904103753_add_document_model/migration.sql
+++ b/prisma/migrations/20250904103753_add_document_model/migration.sql
@@ -1,0 +1,38 @@
+-- CreateEnum
+CREATE TYPE "public"."DocumentStatus" AS ENUM ('DRAFT', 'PUBLISHED', 'ARCHIVED');
+
+-- CreateTable
+CREATE TABLE "public"."Document" (
+    "id" TEXT NOT NULL,
+    "title" VARCHAR(256),
+    "slug" VARCHAR(256),
+    "authorId" TEXT,
+    "status" "public"."DocumentStatus" NOT NULL DEFAULT 'DRAFT',
+    "version" INTEGER NOT NULL DEFAULT 1,
+    "content" JSONB NOT NULL,
+    "draft" JSONB,
+    "plainText" TEXT,
+    "publishedAt" TIMESTAMP(3),
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "Document_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "Document_slug_key" ON "public"."Document"("slug");
+
+-- CreateIndex
+CREATE INDEX "Document_authorId_idx" ON "public"."Document"("authorId");
+
+-- CreateIndex
+CREATE INDEX "Document_status_idx" ON "public"."Document"("status");
+
+-- CreateIndex
+CREATE INDEX "Document_updatedAt_idx" ON "public"."Document"("updatedAt");
+
+-- CreateIndex
+CREATE INDEX "Document_slug_idx" ON "public"."Document"("slug");
+
+-- AddForeignKey
+ALTER TABLE "public"."Document" ADD CONSTRAINT "Document_authorId_fkey" FOREIGN KEY ("authorId") REFERENCES "public"."User"("id") ON DELETE SET NULL ON UPDATE CASCADE;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -38,6 +38,45 @@ model User {
   createdAt     DateTime  @default(now())
   updatedAt     DateTime  @updatedAt
 
+  // Relations
+  documents     Document[]
+
   @@index([role])
   @@index([createdAt])
+}
+
+// --------------------------------------------------
+// Document model (for rich text editor autosave/publish)
+// - content: last committed JSON document (BlockNote JSON)
+// - draft: optional in-progress autosave buffer (not yet committed)
+// - plainText: denormalized text for search/snippets
+// --------------------------------------------------
+
+enum DocumentStatus {
+  DRAFT
+  PUBLISHED
+  ARCHIVED
+}
+
+model Document {
+  id         String          @id @default(cuid())
+  title      String?         @db.VarChar(256)
+  slug       String?         @unique @db.VarChar(256)
+  authorId   String?
+  author     User?           @relation(fields: [authorId], references: [id], onDelete: SetNull)
+  status     DocumentStatus  @default(DRAFT)
+  version    Int             @default(1)
+
+  content    Json            // committed content
+  draft      Json?           // latest autosave (not yet committed)
+  plainText  String?         @db.Text
+
+  publishedAt DateTime?
+  createdAt   DateTime       @default(now())
+  updatedAt   DateTime       @updatedAt
+
+  @@index([authorId])
+  @@index([status])
+  @@index([updatedAt])
+  @@index([slug])
 }


### PR DESCRIPTION
## Description
- Added `Document` model to Prisma schema for rich text editor autosave and publishing.
- Introduced `DocumentStatus` enum (`DRAFT`, `PUBLISHED`, `ARCHIVED`) for document lifecycle management.
- Document fields: `id`, `title`, `slug` (unique), `authorId`, `author` relation, `status`, `version`, `content` (JSON), `draft` (JSON), `plainText`, `publishedAt`, `createdAt`, `updatedAt`.
- Added relation field `documents` to `User` model for authored documents.
- Created migration to update the database schema with new tables, indexes, and foreign key constraints.

This prepares the backend for autosaving and managing rich text documents from the editor.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Introduces Documents with draft, publish, and archive workflow.
  - Autosave for in-progress drafts; separate committed content on publish.
  - Versioning and publish timestamp for better change tracking.
  - Shareable, human-friendly links for documents.
  - Author attribution on documents.
  - Improved browsing with status filters and “recently updated” sorting.
  - Enhanced search readiness via plain-text extraction.

- Chores
  - Backend schema prepared to support document management, filtering, and performance indexing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->