### PR TITLE
Migrate authentication from JWT to Iron Session; update API routes & CI

### DIFF
--- a/.github/workflows/webapp.yml
+++ b/.github/workflows/webapp.yml
@@ -31,5 +31,5 @@ jobs:
       - name: Build project
         run: npm run build
         env:
-          SESSION_SECRET: ${{ github.event_name == 'pull_request' && 'ci-build-secret' || secrets.SESSION_SECRET }}
+          SESSION_SECRET: ${{ github.event_name == 'pull_request' && secrets.CI_SESSION_SECRET || secrets.SESSION_SECRET }}
           NEXT_PUBLIC_WALLETCONNECT_PROJECT_ID: "next-public-walletconnect-project-id"

--- a/.github/workflows/webapp.yml
+++ b/.github/workflows/webapp.yml
@@ -31,5 +31,5 @@ jobs:
       - name: Build project
         run: npm run build
         env:
-          SESSION_SECRET: ${{ github.event_name == 'pull_request' && secrets.CI_SESSION_SECRET || secrets.SESSION_SECRET }}
+          SESSION_SECRET: ${{ github.event_name == 'pull_request' && 'ci-build-session-secret-32-chars-minimum-length-required-for-iron-session' || secrets.SESSION_SECRET }}
           NEXT_PUBLIC_WALLETCONNECT_PROJECT_ID: "next-public-walletconnect-project-id"

--- a/.github/workflows/webapp.yml
+++ b/.github/workflows/webapp.yml
@@ -31,5 +31,5 @@ jobs:
       - name: Build project
         run: npm run build
         env:
-          JWT_SECRET: ${{ github.event_name == 'pull_request' && 'ci-build-secret' || secrets.JWT_SECRET }}
+          SESSION_SECRET: ${{ github.event_name == 'pull_request' && 'ci-build-secret' || secrets.SESSION_SECRET }}
           NEXT_PUBLIC_WALLETCONNECT_PROJECT_ID: "next-public-walletconnect-project-id"

--- a/package-lock.json
+++ b/package-lock.json
@@ -20,6 +20,7 @@
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
         "ethers": "^6.15.0",
+        "iron-session": "^8.0.4",
         "jsonwebtoken": "^9.0.0",
         "lucide-react": "^0.542.0",
         "next": "15.5.2",
@@ -6726,6 +6727,15 @@
         "node": "^14.18.0 || >=16.10.0"
       }
     },
+    "node_modules/cookie": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.2.tgz",
+      "integrity": "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
     "node_modules/cookie-es": {
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/cookie-es/-/cookie-es-1.2.2.tgz",
@@ -9183,6 +9193,21 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/iron-session": {
+      "version": "8.0.4",
+      "resolved": "https://registry.npmjs.org/iron-session/-/iron-session-8.0.4.tgz",
+      "integrity": "sha512-9ivNnaKOd08osD0lJ3i6If23GFS2LsxyMU8Gf/uBUEgm8/8CC1hrrCHFDpMo3IFbpBgwoo/eairRsaD3c5itxA==",
+      "funding": [
+        "https://github.com/sponsors/vvo",
+        "https://github.com/sponsors/brc-dd"
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "cookie": "^0.7.2",
+        "iron-webcrypto": "^1.2.1",
+        "uncrypto": "^0.1.3"
       }
     },
     "node_modules/iron-webcrypto": {

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "ethers": "^6.15.0",
+    "iron-session": "^8.0.4",
     "jsonwebtoken": "^9.0.0",
     "lucide-react": "^0.542.0",
     "next": "15.5.2",

--- a/src/actions/courses/createCourse/action.ts
+++ b/src/actions/courses/createCourse/action.ts
@@ -14,7 +14,8 @@ export const createCourseAction = authActionClient
         }
 
         try {
-            const createdCourseResult = await createCourse(parsedInput, userId); if (createdCourseResult.success) {
+            const createdCourseResult = await createCourse(parsedInput, userId);
+            if (createdCourseResult.success) {
                 return createdCourseResult.data;
             }
 

--- a/src/actions/courses/createCourse/action.ts
+++ b/src/actions/courses/createCourse/action.ts
@@ -8,16 +8,13 @@ export const createCourseAction = authActionClient
     .inputSchema(createCourseSchema)
     .metadata({ actionName: 'createCourse' })
     .action(async ({ parsedInput, ctx }) => {
-        const userId = ctx.session?.user?.id;
+        const userId = ctx.session.user?.id;
         if (!userId) {
-            console.error('Course creation error: missing user in session');
             throw new Error('Not Authorised');
         }
 
         try {
-            const createdCourseResult = await createCourse(parsedInput, userId);
-
-            if (createdCourseResult.success) {
+            const createdCourseResult = await createCourse(parsedInput, userId); if (createdCourseResult.success) {
                 return createdCourseResult.data;
             }
 

--- a/src/app/api/auth/logout/route.ts
+++ b/src/app/api/auth/logout/route.ts
@@ -4,7 +4,9 @@ import { getSession } from "@/lib/session";
 export async function POST() {
     try {
         const session = await getSession();
-        session.destroy();
+        if (session) {
+            await session.destroy();
+        }
 
         return NextResponse.json({ success: true, message: "Logged out successfully" });
     } catch (error) {

--- a/src/app/api/auth/logout/route.ts
+++ b/src/app/api/auth/logout/route.ts
@@ -1,15 +1,14 @@
 import { NextResponse } from "next/server";
-import { COOKIE_NAME } from "@/lib/auth";
+import { getSession } from "@/lib/session";
 
 export async function POST() {
-    const res = NextResponse.json({ success: true });
-    // Expire the session cookie
-    res.cookies.set(COOKIE_NAME, "", {
-        httpOnly: true,
-        secure: process.env.NODE_ENV === "production",
-        sameSite: "lax",
-        path: "/",
-        maxAge: 0,
-    });
-    return res;
+    try {
+        const session = await getSession();
+        session.destroy();
+
+        return NextResponse.json({ success: true, message: "Logged out successfully" });
+    } catch (error) {
+        console.error("Logout error:", error);
+        return NextResponse.json({ error: "Internal server error" }, { status: 500 });
+    }
 }

--- a/src/app/api/users/route.ts
+++ b/src/app/api/users/route.ts
@@ -1,65 +1,34 @@
-import { NextResponse, NextRequest } from "next/server";
+import { NextResponse } from "next/server";
 import { prisma } from "@/lib/prisma";
-import { verifySession, COOKIE_NAME } from "@/lib/auth";
+import { getCurrentUserFromSession } from "@/lib/auth";
 
-// Lightweight wallet address validator: 0x followed by 40 hex chars (EIP-55 checksum not enforced here)
-const isHexAddress = (value: unknown): value is string => {
-    return typeof value === 'string' && /^0x[a-fA-F0-9]{40}$/.test(value);
-};
-
-export async function POST(req: NextRequest) {
+export async function POST() {
     try {
-        // Extract session token from cookie or Authorization header
-        const tokenFromCookie = req.cookies.get(COOKIE_NAME)?.value;
-        const authHeader = req.headers.get("authorization") || "";
-        const tokenFromHeader = authHeader.startsWith("Bearer ") ? authHeader.slice(7) : undefined;
+        // Get user from Iron Session
+        const user = await getCurrentUserFromSession();
 
-        const sessionToken = tokenFromCookie || tokenFromHeader;
-
-        // Verify authentication session
-        if (!sessionToken) {
+        if (!user) {
             return NextResponse.json({
                 error: "Authentication required",
                 message: "Please complete SIWE authentication first"
             }, { status: 401 });
         }
 
-        const session = verifySession(sessionToken);
-        if (!session || !session.walletAddress) {
-            return NextResponse.json({
-                error: "Invalid or expired session",
-                message: "Please re-authenticate using SIWE flow"
-            }, { status: 401 });
-        }
-
-        // Create or update user with verified wallet address from session
-        const rawAddress = session.walletAddress as string;
-
-        // Validate format server-side (0x + 40 hex chars)
-        if (!isHexAddress(rawAddress)) {
-            return NextResponse.json({ error: "invalid walletAddress" }, { status: 400 });
-        }
-
-        const address = rawAddress.toLowerCase();
-
-        const user = await prisma.user.upsert({
-            where: { walletAddress: address },
-            update: { lastLoginAt: new Date() },
-            create: {
-                walletAddress: address,
-                lastLoginAt: new Date()
-            },
+        // Update user's last login time
+        const updatedUser = await prisma.user.update({
+            where: { id: user.id },
+            data: { lastLoginAt: new Date() },
             select: { id: true, walletAddress: true, role: true, lastLoginAt: true, createdAt: true }
         });
 
         return NextResponse.json({
             success: true,
             user: {
-                id: user.id,
-                walletAddress: user.walletAddress,
-                role: user.role,
-                lastLoginAt: user.lastLoginAt,
-                createdAt: user.createdAt
+                id: updatedUser.id,
+                walletAddress: updatedUser.walletAddress,
+                role: updatedUser.role,
+                lastLoginAt: updatedUser.lastLoginAt,
+                createdAt: updatedUser.createdAt
             }
         });
 

--- a/src/app/signup/page.tsx
+++ b/src/app/signup/page.tsx
@@ -40,7 +40,7 @@ export default function SignupPage() {
         const data = await res.json().catch(() => null);
         setError(data?.message || "Signup failed");
       }
-    } catch (err) {
+    } catch {
       setError("Network error. Please try again.");
     } finally {
       setIsSubmitting(false);

--- a/src/lib/action.ts
+++ b/src/lib/action.ts
@@ -1,7 +1,7 @@
-import { getCurrentUserFromCookie } from './auth';
+import { getSession } from './session';
 import { prisma } from './prisma';
 import { createSafeActionClient } from 'next-safe-action';
-import { headers, cookies } from 'next/headers';
+import { headers } from 'next/headers';
 import * as zod from 'zod';
 
 function defineMetadataSchema() {
@@ -20,11 +20,11 @@ export const actionClient = createSafeActionClient({
      * Returns the context with the session object.
      */
     .use(async ({ next }) => {
-        const user = await getCurrentUserFromCookie(await cookies());
+        const session = await getSession();
         const headerList = await headers();
 
         return next({
-            ctx: { session: { user }, headers: headerList }
+            ctx: { session, headers: headerList }
         });
     });
 
@@ -51,6 +51,8 @@ export const authActionClient = actionClient.use(async ({ next, ctx }) => {
         ctx: {
             ...ctx,
             session: {
+                destroy: ctx.session.destroy,
+                save: ctx.session.save,
                 user: {
                     id: user.id
                 }

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -1,8 +1,9 @@
 import { createHash } from "crypto";
 import { prisma } from "@/lib/prisma";
 import { getSession } from "./session";
+import { COOKIE_NAME } from "./constants";
 
-export const COOKIE_NAME = "athena_session";
+export { COOKIE_NAME };
 
 export function hashNonce(nonce: string) {
     return createHash("sha256").update(nonce).digest("hex");

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -1,24 +1,8 @@
-import jwt from "jsonwebtoken";
 import { createHash } from "crypto";
 import { prisma } from "@/lib/prisma";
+import { getSession } from "./session";
 
-interface RequestCookies { get(name: string): { value: string } | undefined; }
-
-const envJwt = process.env.JWT_SECRET;
-if (process.env.NODE_ENV === "production" && (!envJwt || envJwt.trim() === "")) {
-    throw new Error("JWT_SECRET must be set in production environment");
-}
-
-const JWT_SECRET = envJwt ?? "local-dev-secret";
 export const COOKIE_NAME = "athena_session";
-
-export function signSession(payload: Record<string, unknown>) {
-    return jwt.sign(payload, JWT_SECRET, { expiresIn: "7d" });
-}
-
-export function verifySession(token: string) {
-    try { return jwt.verify(token, JWT_SECRET) as Record<string, unknown> | null; } catch { return null; }
-}
 
 export function hashNonce(nonce: string) {
     return createHash("sha256").update(nonce).digest("hex");
@@ -37,19 +21,17 @@ export async function consumeNonce(hashed: string) {
     } catch { return null; }
 }
 
-// Resolve current user from cookie/session
-export async function getCurrentUserFromCookie(cookieStore: RequestCookies | Promise<RequestCookies> | undefined) {
+// Get current user from Iron Session
+export async function getCurrentUserFromSession() {
     try {
-        if (!cookieStore) return null;
-        const store = await cookieStore;
-        const token = store.get(COOKIE_NAME)?.value;
-        if (!token) return null;
-        const session = verifySession(token);
-        if (!session || typeof session.walletAddress !== "string") return null;
-        const addr = (session.walletAddress as string).toLowerCase();
-        const user =
-            (await prisma.user.findUnique({ where: { walletAddress: addr } })) ??
-            (await prisma.user.findFirst({ where: { walletAddress: { equals: addr, mode: "insensitive" } } }));
+        const session = await getSession();
+        if (!session.user?.id) return null;
+
+        const user = await prisma.user.findFirst({
+            where: { id: session.user.id }
+        });
         return user ?? null;
-    } catch { return null; }
+    } catch {
+        return null;
+    }
 }

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -1,0 +1,29 @@
+export const COOKIE_NAME = "athena_session";
+
+// Session configuration
+export const SESSION_CONFIG = {
+    MAX_AGE: 7 * 24 * 60 * 60, // 7 days
+    SECURE: process.env.NODE_ENV === "production",
+    HTTP_ONLY: true,
+    SAME_SITE: "lax" as const,
+    PATH: "/",
+} as const;
+
+// Auth constants
+export const AUTH_CONSTANTS = {
+    NONCE_EXPIRY_MINUTES: 10,
+    MIN_SESSION_SECRET_LENGTH: 32,
+} as const;
+
+// API Error messages
+export const ERROR_MESSAGES = {
+    UNAUTHORIZED: "Unauthorized",
+    INVALID_JSON: "Invalid JSON",
+    MISSING_FIELDS: "Missing required fields",
+    INVALID_NONCE: "Invalid or expired nonce",
+    INVALID_SIGNATURE: "Invalid signature",
+    AUTHENTICATION_FAILED: "Authentication failed",
+    NETWORK_ERROR: "Network error. Please try again.",
+    INTERNAL_ERROR: "Internal server error",
+    SESSION_EXPIRED: "Session expired",
+} as const;

--- a/src/lib/env.ts
+++ b/src/lib/env.ts
@@ -1,0 +1,18 @@
+// Environment variables with validation
+const envSessionSecret = process.env.SESSION_SECRET;
+if (process.env.NODE_ENV === "production" && (!envSessionSecret || envSessionSecret.trim() === "")) {
+    throw new Error("SESSION_SECRET must be set in production environment");
+}
+
+if (process.env.NODE_ENV === "production" && envSessionSecret && envSessionSecret.length < 32) {
+    throw new Error("SESSION_SECRET must be at least 32 characters long in production");
+}
+
+export const SESSION_SECRET = envSessionSecret ?? "local-dev-session-secret-32-chars-min";
+export const NODE_ENV = process.env.NODE_ENV || "development";
+export const SIWE_DOMAIN = process.env.SIWE_DOMAIN;
+export const SIWE_URI = process.env.SIWE_URI;
+export const SIWE_CHAIN_ID = process.env.SIWE_CHAIN_ID ? parseInt(process.env.SIWE_CHAIN_ID, 10) : undefined;
+export const SIWE_STATEMENT = process.env.SIWE_STATEMENT;
+export const SIWE_RPC_URL = process.env.SIWE_RPC_URL || process.env.RPC_URL;
+export const NEXT_PUBLIC_WALLETCONNECT_PROJECT_ID = process.env.NEXT_PUBLIC_WALLETCONNECT_PROJECT_ID;

--- a/src/lib/env.ts
+++ b/src/lib/env.ts
@@ -1,3 +1,4 @@
+import "server-only";
 // Environment variables with validation
 const envSessionSecret = process.env.SESSION_SECRET;
 if (process.env.NODE_ENV === "production" && (!envSessionSecret || envSessionSecret.trim() === "")) {

--- a/src/lib/session.ts
+++ b/src/lib/session.ts
@@ -1,5 +1,7 @@
 import { getIronSession } from 'iron-session';
 import { cookies } from 'next/headers';
+import { SESSION_SECRET } from './env';
+import { COOKIE_NAME, SESSION_CONFIG } from './constants';
 
 export type SessionData = {
     user?: {
@@ -7,27 +9,16 @@ export type SessionData = {
     };
 };
 
-const sessionSecret = process.env.SESSION_SECRET;
-if (process.env.NODE_ENV === 'production') {
-    if (!sessionSecret || sessionSecret.trim() === '') {
-        throw new Error('SESSION_SECRET must be set in production environment');
-    }
-    if (sessionSecret.length < 32) {
-        throw new Error('SESSION_SECRET must be at least 32 characters long in production');
-    }
-}
-
-const SESSION_PASSWORD = sessionSecret ?? 'local-dev-session-secret-32-chars-min';
-const cookieName = 'athena_session';
-const IS_PRODUCTION = process.env.NODE_ENV === 'production';
-
 export async function getSession() {
     const session = await getIronSession<SessionData>(await cookies(), {
-        password: SESSION_PASSWORD,
-        cookieName: cookieName,
+        password: SESSION_SECRET,
+        cookieName: COOKIE_NAME,
         cookieOptions: {
-            secure: IS_PRODUCTION,
-            httpOnly: true
+            secure: SESSION_CONFIG.SECURE,
+            httpOnly: SESSION_CONFIG.HTTP_ONLY,
+            sameSite: SESSION_CONFIG.SAME_SITE,
+            path: SESSION_CONFIG.PATH,
+            maxAge: SESSION_CONFIG.MAX_AGE,
         }
     });
 

--- a/src/lib/session.ts
+++ b/src/lib/session.ts
@@ -8,8 +8,13 @@ export type SessionData = {
 };
 
 const sessionSecret = process.env.SESSION_SECRET;
-if (process.env.NODE_ENV === 'production' && (!sessionSecret || sessionSecret.trim() === '')) {
-    throw new Error('SESSION_SECRET must be set in production environment');
+if (process.env.NODE_ENV === 'production') {
+    if (!sessionSecret || sessionSecret.trim() === '') {
+        throw new Error('SESSION_SECRET must be set in production environment');
+    }
+    if (sessionSecret.length < 32) {
+        throw new Error('SESSION_SECRET must be at least 32 characters long in production');
+    }
 }
 
 const SESSION_PASSWORD = sessionSecret ?? 'local-dev-session-secret-32-chars-min';

--- a/src/lib/session.ts
+++ b/src/lib/session.ts
@@ -1,0 +1,30 @@
+import { getIronSession } from 'iron-session';
+import { cookies } from 'next/headers';
+
+export type SessionData = {
+    user?: {
+        id: string;
+    };
+};
+
+const sessionSecret = process.env.SESSION_SECRET;
+if (process.env.NODE_ENV === 'production' && (!sessionSecret || sessionSecret.trim() === '')) {
+    throw new Error('SESSION_SECRET must be set in production environment');
+}
+
+const SESSION_PASSWORD = sessionSecret ?? 'local-dev-session-secret-32-chars-min';
+const cookieName = 'athena_session';
+const IS_PRODUCTION = process.env.NODE_ENV === 'production';
+
+export async function getSession() {
+    const session = await getIronSession<SessionData>(await cookies(), {
+        password: SESSION_PASSWORD,
+        cookieName: cookieName,
+        cookieOptions: {
+            secure: IS_PRODUCTION,
+            httpOnly: true
+        }
+    });
+
+    return session;
+}


### PR DESCRIPTION
This PR completes the migration of session management from JWT tokens to Iron Session (encrypted cookie-based sessions). It centralizes session handling and improves security by storing session data server-side-encrypted in cookies.

- Replace JWT-based session handling with Iron Session (encrypted cookie) across the app.
- Update [auth.ts] to remove JWT helpers and add Iron Session helpers.
- Update API routes to create/read/destroy sessions via Iron Session:
      - [route.ts]  — create Iron Session after SIWE verification.
      - [route.ts] — read current user from Iron Session.
      - [route.ts] — expire/destroy Iron Session.
- Update GitHub Actions workflow to use [SESSION_SECRET] instead of JWT_SECRET.
- Fix lint warnings and ensure a successful production build (with a temporary SESSION_SECRET for local builds).
- Remove remaining JWT references and confirm no regressions in lint/build

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Authentication now uses secure server-side sessions; verification/signup create users automatically and return JSON responses.

- Bug Fixes
  - Logout returns a clear success message and explicit 500 error responses on failure; verification flows return proper HTTP statuses.

- Refactor
  - Session handling and auth flows standardized across APIs; centralized session/config constants.

- Chores
  - CI build switched to a session secret for PR/non-PR builds; added server-side session dependency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->