### PR TITLE
refactor: Rename PathSelectionPageContainer to HomePageContainer

### DIFF
--- a/src/app/general/page.tsx
+++ b/src/app/general/page.tsx
@@ -1,5 +1,5 @@
-import { PathSelectionPageContainer } from '@/components/pages/home/PathSelectionPageContainer';
+import { HomePageContainer } from '@/components/pages/home/HomePageContainer';
 
 export default function HomePage() {
-  return <PathSelectionPageContainer />;
+  return <HomePageContainer />;
 }

--- a/src/components/pages/home/HomePageContainer.tsx
+++ b/src/components/pages/home/HomePageContainer.tsx
@@ -6,7 +6,7 @@ import Navbar from '@/components/common/Navbar';
 import Image from 'next/image';
 import { PathOption } from '@/components/common/PathOption';
 
-export function PathSelectionPageContainer() {
+export function HomePageContainer() {
   const router = useRouter();
 
   const handleStudent = React.useCallback(() => {


### PR DESCRIPTION
Renames `PathSelectionPageContainer.tsx` to `HomePageContainer.tsx` for better clarity and consistency in naming. All references to the component have been updated accordingly.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Refactor
  - Renamed the home page container and updated references to use it in the general app page.
  - Consolidated rendering so the home experience is served by a single container.
  - No changes to workflows, visuals, navigation, or performance.

- Chores
  - Aligned internal imports/exports to reflect the updated component name.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->